### PR TITLE
Add database-backed schema retrieval and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ annex4ac fetch-schema annex_template.yaml
 
 | `--source-preference` | Behaviour |
 | --------------------- | ---------- |
-| `db_only`             | Use DB only; exit code 2 if unreachable or CELEX missing |
+| `db_only`             | Use DB only; exit code 2 if unreachable or regulation missing |
 | `web_only`            | Ignore DB and fetch from the official website |
 | `db_then_web` (default) | Try DB first, fall back to web on error |
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ SaaS/PDF unlocks with a licence key .
 
 ```bash
 # 1 Install (Python 3.9+) - includes all dependencies
-pip install annex4ac
+pip install annex4ac  # pulls SQLAlchemy 2.x and psycopg[binary]
+# On Alpine, install build tools (e.g., gcc) before pip install
 
 # 2 Pull the latest Annex IV layout
 annex4ac fetch-schema annex_template.yaml

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ If Annex IV is temporarily unavailable online, use:
 annex4ac fetch-schema --offline
 ```
 
-This loads the last saved schema from the user cache directory (e.g. `~/.cache/annex4ac` on Linux). The cache updates automatically every 14 days.
+This loads the last saved schema from the user cache directory (e.g. `~/.cache/annex4ac` on Linux). Re-run `fetch-schema` to refresh the cache.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ annex4ac validate my_annex.yaml   # "Validation OK!" or exit 1
 annex4ac validate my_annex.yaml --stale-after 30  # Warn if older than 30 days
 annex4ac validate my_annex.yaml --stale-after 180 --strict-age  # Fail CI if older than 180 days
 # Cross-check sections against the database and emit SARIF for GitHub
-annex4ac validate my_annex.yaml --use-db --db-url "$ANNEX4AC_DB_URL" --sarif out.sarif
-# This checks the minimum required count of top-level and nested subpoints, not literal (a)/(b)/(c) markers
+annex4ac validate my_annex.yaml --use-db --db-url "$ANNEX4AC_DB_URL" --explain --sarif out.sarif
+# --explain lists missing lettered subpoints like (c) or (d). This checks the minimum required count of
+# top-level and nested subpoints, not literal (a)/(b)/(c) markers
 
 # 4 Generate output (PDF requires license)
 # HTML (free) - automatically validates before generation

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Found 3 total issue(s): 2 errors, 1 warnings
 
 ## 🏷️ High-risk tags (Annex III)
 
-The list of high-risk tags (Annex III) is now loaded dynamically from the official website. If the network is unavailable, a cache or fallback list is used. This affects the auto_high_risk logic in validation.
+The list of high-risk tags (Annex III) is now loaded dynamically from the official website. If the network is unavailable, a cache or packaged fallback list is used. To refresh the local cache manually, run `annex4ac update-annex3-cache`. This affects the auto_high_risk logic in validation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ annex4ac validate my_annex.yaml --stale-after 30  # Warn if older than 30 days
 annex4ac validate my_annex.yaml --stale-after 180 --strict-age  # Fail CI if older than 180 days
 # Cross-check sections against the database and emit SARIF for GitHub
 annex4ac validate my_annex.yaml --use-db --db-url "$ANNEX4AC_DB_URL" --sarif out.sarif
+# This checks the minimum required count of top-level and nested subpoints, not literal (a)/(b)/(c) markers
 
 # 4 Generate output (PDF requires license)
 # HTML (free) - automatically validates before generation

--- a/README.md
+++ b/README.md
@@ -23,10 +23,16 @@ pip install annex4ac  # pulls SQLAlchemy 2.x and psycopg[binary]
 # 2 Pull the latest Annex IV layout
 annex4ac fetch-schema annex_template.yaml
 # Optional: fetch from a local PostgreSQL snapshot (SQLAlchemy URL with psycopg3)
-# export ANNEX4AC_DB_URL="postgresql+psycopg://user:pass@host:5432/ai_act"
+# export ANNEX4AC_DB_URL="postgresql+psycopg://user:pass@host:5432/ai_act"  # see https://docs.sqlalchemy.org/en/20/dialects/postgresql.html
 # annex4ac fetch-schema --db-url "$ANNEX4AC_DB_URL" annex_template.yaml
 # annex4ac fetch-schema --db-url "$ANNEX4AC_DB_URL" --source-preference db_only annex_template.yaml  # fail if DB missing
 # (Database mode is currently tested only with PostgreSQL.)
+
+| `--source-preference` | Behaviour |
+| --------------------- | ---------- |
+| `db_only`             | Use DB only; exit code 2 if unreachable or CELEX missing |
+| `web_only`            | Ignore DB and fetch from the official website |
+| `db_then_web` (default) | Try DB first, fall back to web on error |
 
 # 3 Fill in the YAML → validate
 cp annex_template.yaml my_annex.yaml
@@ -114,7 +120,8 @@ annex4nlp doc1.pdf doc2.pdf  # Compare multiple documents for contradictions
 | Command        | What it does                                                                  |
 | -------------- | ----------------------------------------------------------------------------- |
 | `fetch-schema` | Download the current Annex IV scaffold from the web or a PostgreSQL DB (`--db-url`, `--source-preference`). |
-| `validate`     | Validate your YAML against the Pydantic schema and built-in Python rules. Exits 1 on error. Supports `--sarif` for GitHub annotations, `--stale-after` for optional freshness heuristic, and `--strict-age` for strict age checking.             |
+| `update-annex3-cache` | Refresh cached Annex III high-risk tags stored under the user cache directory. |
+| `validate`     | Validate your YAML against the Pydantic schema and built-in Python rules. Exits 1 on error. Supports `--sarif` for GitHub annotations, `--stale-after` for optional freshness heuristic, and `--strict-age` for strict age checking. |
 | `generate`     | Render PDF (Pro), HTML, or DOCX from YAML. Validates by default (`--skip-validation` to bypass). PDF requires license, HTML/DOCX are free. |
 | `annex4nlp`       | Review functionality has been moved to `annex4nlp` package. Analyze PDF technical documentation for compliance issues, missing sections, and contradictions between documents. Uses advanced NLP for intelligent negation detection. Provides detailed console output with error/warning classification.|
 
@@ -208,7 +215,7 @@ Found 3 total issue(s): 2 errors, 1 warnings
 
 ## 🏷️ High-risk tags (Annex III)
 
-The list of high-risk tags (Annex III) is now loaded dynamically from the official website. If the network is unavailable, a cache or packaged fallback list is used. To refresh the local cache manually, run `annex4ac update-annex3-cache`. This affects the auto_high_risk logic in validation.
+The list of high-risk tags (Annex III) is now loaded dynamically from the official website. If the network is unavailable, a cache or packaged fallback list is used. The cache lives in the user cache directory (e.g., `~/.cache/annex4ac` on Linux) via `platformdirs`. Refresh it manually with `annex4ac update-annex3-cache`. This affects the auto_high_risk logic in validation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ annex4ac validate my_annex.yaml   # "Validation OK!" or exit 1
 # Optional: Check if document is stale (heuristic, not legal requirement)
 annex4ac validate my_annex.yaml --stale-after 30  # Warn if older than 30 days
 annex4ac validate my_annex.yaml --stale-after 180 --strict-age  # Fail CI if older than 180 days
+# Cross-check sections against the database and emit SARIF for GitHub
+annex4ac validate my_annex.yaml --use-db --db-url "$ANNEX4AC_DB_URL" --sarif out.sarif
 
 # 4 Generate output (PDF requires license)
 # HTML (free) - automatically validates before generation

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ pip install annex4ac
 
 # 2 Pull the latest Annex IV layout
 annex4ac fetch-schema annex_template.yaml
+# Optional: fetch from a local PostgreSQL snapshot (SQLAlchemy URL with psycopg3)
+# export ANNEX4AC_DB_URL="postgresql+psycopg://user:pass@host:5432/ai_act"
+# annex4ac fetch-schema --db-url "$ANNEX4AC_DB_URL" annex_template.yaml
+# annex4ac fetch-schema --db-url "$ANNEX4AC_DB_URL" --source-preference db_only annex_template.yaml  # fail if DB missing
+# (Database mode is currently tested only with PostgreSQL.)
 
 # 3 Fill in the YAML → validate
 cp annex_template.yaml my_annex.yaml
@@ -105,9 +110,9 @@ annex4nlp doc1.pdf doc2.pdf  # Compare multiple documents for contradictions
 
 | Command        | What it does                                                                  |
 | -------------- | ----------------------------------------------------------------------------- |
-| `fetch-schema` | Download the current Annex IV HTML, convert to YAML scaffold `annex_schema.yaml`. |
+| `fetch-schema` | Download the current Annex IV scaffold from the web or a PostgreSQL DB (`--db-url`, `--source-preference`). |
 | `validate`     | Validate your YAML against the Pydantic schema and built-in Python rules. Exits 1 on error. Supports `--sarif` for GitHub annotations, `--stale-after` for optional freshness heuristic, and `--strict-age` for strict age checking.             |
-| `generate`     | Render PDF (Pro), HTML, or DOCX from YAML. Automatically validates before generation. PDF requires license, HTML/DOCX are free. |
+| `generate`     | Render PDF (Pro), HTML, or DOCX from YAML. Validates by default (`--skip-validation` to bypass). PDF requires license, HTML/DOCX are free. |
 | `annex4nlp`       | Review functionality has been moved to `annex4nlp` package. Analyze PDF technical documentation for compliance issues, missing sections, and contradictions between documents. Uses advanced NLP for intelligent negation detection. Provides detailed console output with error/warning classification.|
 
 Run `annex4ac --help` for full CLI.
@@ -257,7 +262,7 @@ If Annex IV is temporarily unavailable online, use:
 annex4ac fetch-schema --offline
 ```
 
-This will load the last saved schema from `~/.cache/annex4ac/` (the cache is updated automatically every 14 days).
+This loads the last saved schema from the user cache directory (e.g. `~/.cache/annex4ac` on Linux). The cache updates automatically every 14 days.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@ annex4ac fetch-schema annex_template.yaml
 # annex4ac fetch-schema --db-url "$ANNEX4AC_DB_URL" --source-preference db_only annex_template.yaml  # fail if DB missing
 # (Database mode is currently tested only with PostgreSQL.)
 
+```
+
 | `--source-preference` | Behaviour |
 | --------------------- | ---------- |
 | `db_only`             | Use DB only; exit code 2 if unreachable or CELEX missing |
 | `web_only`            | Ignore DB and fetch from the official website |
 | `db_then_web` (default) | Try DB first, fall back to web on error |
 
+```bash
 # 3 Fill in the YAML → validate
 cp annex_template.yaml my_annex.yaml
 $EDITOR my_annex.yaml

--- a/annex4ac/__init__.py
+++ b/annex4ac/__init__.py
@@ -1,5 +1,6 @@
-from .annex4ac import app
+from .annex4ac import app, fetch_annex3_tags
 
 __all__ = [
-    'app'
-] 
+    "app",
+    "fetch_annex3_tags",
+]

--- a/annex4ac/__init__.py
+++ b/annex4ac/__init__.py
@@ -1,6 +1,4 @@
-from .annex4ac import app, fetch_annex3_tags
+from .annex4ac import app
+from .tags import fetch_annex3_tags
 
-__all__ = [
-    "app",
-    "fetch_annex3_tags",
-]
+__all__ = ["app", "fetch_annex3_tags"]

--- a/annex4ac/annex4ac.py
+++ b/annex4ac/annex4ac.py
@@ -1021,7 +1021,7 @@ def validate(
                         letters.append(m.group(1).lower())
                 return letters
 
-            for idx, (_, key) in enumerate(SECTION_MAPPING, start=1):
+            for _, key in SECTION_MAPPING:
                 db_text = db_schema.get(key)
                 user_text = str(payload.get(key) or "").strip()
                 if not db_text:
@@ -1032,13 +1032,12 @@ def validate(
                         "msg": f"Annex IV requires content for '{key}' (per current DB snapshot).",
                     })
                     continue
-                if idx in (1, 2):
-                    for letter in _extract_subpoints(db_text):
-                        if not re.search(rf"\({letter}\)", user_text, re.I):
-                            violations.append({
-                                "rule": f"{key}_{letter}_required",
-                                "msg": f"Section '{key}' requires subpoint ({letter}) (per current DB snapshot).",
-                            })
+                for letter in _extract_subpoints(db_text):
+                    if not re.search(rf"\({letter}\)", user_text, re.I):
+                        violations.append({
+                            "rule": f"{key}_{letter}_required",
+                            "msg": f"Section '{key}' requires subpoint ({letter}) (per current DB snapshot).",
+                        })
 
         if sarif and violations:
             _write_sarif(violations, sarif, str(input))

--- a/annex4ac/annex4ac.py
+++ b/annex4ac/annex4ac.py
@@ -889,7 +889,7 @@ def _check_license():
         typer.secho(f"License plan '{plan}' insufficient for PDF generation", fg=typer.colors.RED)
         raise typer.Exit(1)
 
-@app.command()
+@app.command("update-annex3-cache")
 def update_annex3_cache():
     """Force-update cached Annex III high-risk tags."""
     tags = fetch_annex3_tags(cache_days=0)

--- a/annex4ac/annex4ac.py
+++ b/annex4ac/annex4ac.py
@@ -1019,7 +1019,7 @@ def validate(
                         letters.append(m.group(1).lower())
                 return letters
 
-            for _, key in SECTION_MAPPING:
+            for idx, (_, key) in enumerate(SECTION_MAPPING, start=1):
                 db_text = db_schema.get(key)
                 user_text = str(payload.get(key) or "").strip()
                 if not db_text:
@@ -1030,12 +1030,13 @@ def validate(
                         "msg": f"Annex IV requires content for '{key}' (per current DB snapshot).",
                     })
                     continue
-                for letter in _extract_subpoints(db_text):
-                    if not re.search(rf"\({letter}\)", user_text, re.I):
-                        violations.append({
-                            "rule": f"{key}_{letter}_required",
-                            "msg": f"Section '{key}' requires subpoint ({letter}) (per current DB snapshot).",
-                        })
+                if idx in (1, 2):
+                    for letter in _extract_subpoints(db_text):
+                        if not re.search(rf"\({letter}\)", user_text, re.I):
+                            violations.append({
+                                "rule": f"{key}_{letter}_required",
+                                "msg": f"Section '{key}' requires subpoint ({letter}) (per current DB snapshot).",
+                            })
 
         if sarif and violations:
             _write_sarif(violations, sarif, str(input))

--- a/annex4ac/annex4ac.py
+++ b/annex4ac/annex4ac.py
@@ -117,9 +117,9 @@ except ImportError:
     PIKEPDF_AVAILABLE = False
 
 # Regular expressions for parsing lists
-BULLET_RE = re.compile(r'^\s*(?:[\u2022\u25CF\u25AA\-\*])\s+')
+BULLET_RE = re.compile(r'^\s*(?:[\u2022\u25CF\u25AA\u00B7\u2013\u2014\-\*])\s+')
 SUBPOINT_RE = re.compile(r'^\s*\(([a-h])\)\s+', re.I)  # (a)...(h); avoids roman (i)
-TOP_BULLET_RE = re.compile(r'^\s{0,3}(?:[-*•]|\d+[\.)])\s+')
+TOP_BULLET_RE = re.compile(r'^\s{0,3}(?:[-*\u2022\u25AA\u00B7\u2013\u2014]|\d+[\.)])\s+')
 ROMAN_RE = re.compile(r'^\s*\(([ivxlcdm]+)\)\s+', re.I)
 
 
@@ -157,7 +157,8 @@ def _count_subpoints_db(db_text: str) -> tuple[int, int]:
             while j < len(lines):
                 ln = lines[j]
                 if ln.strip() == "":
-                    break
+                    j += 1
+                    continue
                 indent = len(re.match(r"^\s*", ln).group(0))
                 if TOP_BULLET_RE.match(ln) and indent <= indent_top:
                     break
@@ -197,7 +198,8 @@ def _count_subpoints_user(user_text: str) -> tuple[int, int]:
         while j < len(lines):
             ln = lines[j]
             if ln.strip() == "":
-                break
+                j += 1
+                continue
             indent = len(re.match(r"^\s*", ln).group(0))
             if TOP_BULLET_RE.match(ln) and indent <= indent_top:
                 break

--- a/annex4ac/annex4ac.py
+++ b/annex4ac/annex4ac.py
@@ -118,8 +118,8 @@ except ImportError:
 
 # Regular expressions for parsing lists
 BULLET_RE = re.compile(r'^\s*(?:[\u2022\u25CF\u25AA\-\*])\s+')
-SUBPOINT_RE = re.compile(r'^\s*\(([a-z])\)\s+', re.I)  # (a), (b)...
-TOP_BULLET_RE = re.compile(r'^\s{0,3}(?:[-*•]|\d+\.)\s+')
+SUBPOINT_RE = re.compile(r'^\s*\(([a-h])\)\s+', re.I)  # (a)...(h); avoids roman (i)
+TOP_BULLET_RE = re.compile(r'^\s{0,3}(?:[-*•]|\d+[\.)])\s+')
 ROMAN_RE = re.compile(r'^\s*\(([ivxlcdm]+)\)\s+', re.I)
 
 
@@ -127,7 +127,7 @@ def _normalize_lines(text: str) -> list[str]:
     if not text:
         return []
     text = fix_text(text)
-    text = text.replace('\r\n', '\n').replace('\r', '\n').replace('\n', '\n')
+    text = text.replace('\r\n', '\n').replace('\r', '\n')
     return [ln.rstrip() for ln in text.splitlines()]
 
 

--- a/annex4ac/annex4ac.py
+++ b/annex4ac/annex4ac.py
@@ -1030,7 +1030,7 @@ def fetch_schema(
     output: Path = typer.Argument(Path("annex_schema.yaml"), exists=False),
     offline: bool = typer.Option(False, help="Use offline cache if available"),
     db_url: str = typer.Option(None, help="SQLAlchemy DB URL (postgresql+psycopg://...)"),
-    celex_id: str = typer.Option("32024R1689", help="CELEX id"),
+    celex_id: Optional[str] = typer.Option(None, help="CELEX id (optional)"),
     source_preference: Optional[SourcePref] = typer.Option(
         None, help="db_only|web_only|db_then_web"
     ),
@@ -1076,7 +1076,7 @@ def fetch_schema(
 
         if source_preference == "db_only" and not data:
             typer.secho(
-                "DB not reachable or CELEX not found. Check ANNEX4AC_DB_URL, network, and permissions, or switch to --source-preference web_only.",
+                "DB not reachable or regulation not found. Check ANNEX4AC_DB_URL or switch to --source-preference web_only.",
                 fg=typer.colors.RED,
                 err=True,
             )
@@ -1111,7 +1111,7 @@ def validate(
     strict_age: bool = typer.Option(False, help="Exit 1 if stale_after is exceeded"),
     use_db: bool = typer.Option(False, help="Cross-check sections against DB"),
     db_url: str = typer.Option(None, help="SQLAlchemy DB URL (postgresql+psycopg://...)"),
-    celex_id: str = typer.Option("32024R1689", help="CELEX id"),
+    celex_id: Optional[str] = typer.Option(None, help="CELEX id (optional)"),
     explain: bool = typer.Option(False, help="Show which subpoints are missing when using --use-db"),
 ):
     """Validate user YAML against required Annex IV keys; exit 1 on error."""

--- a/annex4ac/annex4ac.py
+++ b/annex4ac/annex4ac.py
@@ -380,7 +380,7 @@ class AnnexIVSection(BaseModel):
 class AnnexIVSchema(BaseModel):
     enterprise_size: Literal["sme", "mid", "large"]  # Art. 11 exemption - all sizes get full 9 sections
     risk_level: Literal["high", "limited", "minimal"]
-    use_cases: List[str] = []  # list of tags from Annex III
+    use_cases: List[str] = Field(default_factory=list)  # list of tags from Annex III
     system_overview: str
     development_process: str
     system_monitoring: str

--- a/annex4ac/annex4ac.py
+++ b/annex4ac/annex4ac.py
@@ -946,12 +946,15 @@ def _write_sarif(violations, sarif_path, yaml_path):
                         "level": "error",
                         "ruleId": v["rule"],
                         "message": {"text": v["msg"]},
-                        **({"help": {"text": v["help"]}} if v.get("help") else {}),
+                        **({"properties": {"help": v["help"]}} if v.get("help") else {}),
                         "locations": [
                             {
                                 "physicalLocation": {
                                     "artifactLocation": {"uri": yaml_path or "annex.yaml"},
-                                    "region": {"startLine": key_lines.get(v["rule"], (1,1))[0], "startColumn": key_lines.get(v["rule"], (1,1))[1]}
+                                    "region": {
+                                        "startLine": key_lines.get(v["rule"], (1,1))[0],
+                                        "startColumn": key_lines.get(v["rule"], (1,1))[1]
+                                    }
                                 }
                             }
                         ]

--- a/annex4ac/config.py
+++ b/annex4ac/config.py
@@ -8,6 +8,6 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="ANNEX4AC_")
 
     db_url: Optional[str] = None            # postgresql+psycopg://...
-    celex_id: str = "32024R1689"
+    celex_id: Optional[str] = None          # optional CELEX override
     source_preference: Literal["db_only", "web_only", "db_then_web"] = "db_then_web"
 

--- a/annex4ac/config.py
+++ b/annex4ac/config.py
@@ -1,0 +1,13 @@
+from typing import Literal, Optional
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime configuration loaded from environment variables."""
+
+    model_config = SettingsConfigDict(env_prefix="ANNEX4AC_")
+
+    db_url: Optional[str] = None            # postgresql+psycopg://...
+    celex_id: str = "32024R1689"
+    source_preference: Literal["db_only", "web_only", "db_then_web"] = "db_then_web"
+

--- a/annex4ac/constants.py
+++ b/annex4ac/constants.py
@@ -9,7 +9,7 @@ SCHEMA_VERSION = "20240726"
 AI_ACT_ANNEX_IV_HTML = "https://artificialintelligenceact.eu/annex/4/"
 # Fallback – Official Journal PDF (for archival integrity)
 AI_ACT_ANNEX_IV_PDF = (
-    "https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=OJ%3AL_202401689"
+    "https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32024R1689"
 )
 
 # Document control fields (common metadata)

--- a/annex4ac/db.py
+++ b/annex4ac/db.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+import re
+from collections import defaultdict
+from typing import Dict, Optional
+from sqlalchemy import create_engine, select, String, Text, ForeignKey
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, Session
+from .constants import SECTION_MAPPING, SECTION_KEYS
+
+
+class Base(DeclarativeBase): ...
+
+
+class Regulation(Base):
+    __tablename__ = "regulations"
+    id: Mapped[str] = mapped_column(primary_key=True)
+    celex_id: Mapped[str] = mapped_column(String(32))
+    version: Mapped[str] = mapped_column(String(32))
+
+
+class Rule(Base):
+    __tablename__ = "rules"
+    id: Mapped[str] = mapped_column(primary_key=True)
+    regulation_id: Mapped[str] = mapped_column(ForeignKey("regulations.id"))
+    section_code: Mapped[str] = mapped_column(String(64))
+    title: Mapped[Optional[str]] = mapped_column(Text)
+    content: Mapped[str] = mapped_column(Text)
+    order_index: Mapped[Optional[int]] = mapped_column(nullable=True)
+
+
+def get_session(db_url: str) -> Session:
+    """Return a short-lived SQLAlchemy session for CLI commands.
+
+    We intentionally avoid a global ``sessionmaker`` factory; each CLI invocation
+    acquires its own connection from the engine's pool and disposes it promptly.
+    """
+    engine = create_engine(db_url, pool_pre_ping=True)
+    return Session(engine)
+
+
+_ANNEX_RE = re.compile(r"^AnnexIV\.(\d+)", re.I)
+
+
+def _annex_key_from_section_code(sc: str) -> Optional[str]:
+    m = _ANNEX_RE.match(sc or "")
+    if not m:
+        return None
+    n = int(m.group(1))
+    if 1 <= n <= len(SECTION_KEYS):
+        return SECTION_KEYS[n-1]
+    return None
+
+
+def load_annex_iv_from_db(ses: Session, celex_id: str = "32024R1689") -> Dict[str, str]:
+    reg_id = ses.execute(
+        select(Regulation.id).where(Regulation.celex_id == celex_id)
+    ).scalar_one_or_none()
+    if reg_id is None:
+        raise ValueError(f"CELEX {celex_id} not found in database")
+
+    rows = ses.execute(
+        select(Rule.section_code, Rule.content)
+        .where(Rule.regulation_id == reg_id, Rule.section_code.like("AnnexIV%"))
+        .order_by(Rule.order_index.asc().nulls_last(), Rule.section_code.asc())
+    ).all()
+
+    buckets: dict[str, list[str]] = defaultdict(list)
+    for sc, content in rows:
+        key = _annex_key_from_section_code(sc)
+        if key:
+            buckets[key].append((content or "").strip())
+
+    out: Dict[str, str] = {}
+    for _, key in SECTION_MAPPING:
+        out[key] = "\n\n".join([x for x in buckets.get(key, []) if x])
+    return out
+
+
+def get_schema_version_from_db(ses: Session, celex_id: str = "32024R1689") -> Optional[str]:
+    return ses.execute(
+        select(Regulation.version).where(Regulation.celex_id == celex_id)
+    ).scalar_one_or_none()

--- a/annex4ac/fonts/__init__.py
+++ b/annex4ac/fonts/__init__.py
@@ -1,0 +1,1 @@
+# package marker

--- a/annex4ac/policy/annex4ac_validate.py
+++ b/annex4ac/policy/annex4ac_validate.py
@@ -16,8 +16,8 @@ try:
     HIGH_RISK_TAGS = fetch_annex3_tags()
 except Exception:
     data = (
-        files("annex4ac.resources")
-        .joinpath("high_risk_tags.default.json")
+        files("annex4ac")
+        .joinpath("resources/high_risk_tags.default.json")
         .read_text(encoding="utf-8")
     )
     HIGH_RISK_TAGS = set(json.loads(data))

--- a/annex4ac/policy/annex4ac_validate.py
+++ b/annex4ac/policy/annex4ac_validate.py
@@ -12,7 +12,7 @@ import yaml
 from importlib.resources import files
 
 try:
-    from annex4ac import fetch_annex3_tags
+    from annex4ac.tags import fetch_annex3_tags
     HIGH_RISK_TAGS = fetch_annex3_tags()
 except Exception:
     data = (

--- a/annex4ac/policy/annex4ac_validate.py
+++ b/annex4ac/policy/annex4ac_validate.py
@@ -9,28 +9,23 @@ Replaces Rego-based OPA rules with pure-Python logic.
 import sys
 import json
 import yaml
-# Add import for dynamic high risk tags loading
+from importlib.resources import files
+
 try:
     from annex4ac import fetch_annex3_tags
-except ImportError:
-    fetch_annex3_tags = None
+    HIGH_RISK_TAGS = fetch_annex3_tags()
+except Exception:
+    data = (
+        files("annex4ac.resources")
+        .joinpath("high_risk_tags.default.json")
+        .read_text(encoding="utf-8")
+    )
+    HIGH_RISK_TAGS = set(json.loads(data))
+
 
 # -----------------------------------------------------------------------------
 # Configuration of rules (translated from Rego)
 # -----------------------------------------------------------------------------
-
-# Dynamic HIGH_RISK_TAGS loading with fallback
-try:
-    if fetch_annex3_tags:
-        HIGH_RISK_TAGS = fetch_annex3_tags()
-    else:
-        raise Exception("fetch_annex3_tags not available")
-except Exception:
-    HIGH_RISK_TAGS = {
-        "employment_screening", "biometric_id", "critical_infrastructure",
-        "education_scoring", "justice_decision", "migration_control",
-        "essential_services", "law_enforcement",
-    }
 
 PROHIBITED_TAGS = {
     "social_scoring",

--- a/annex4ac/resources/high_risk_tags.default.json
+++ b/annex4ac/resources/high_risk_tags.default.json
@@ -1,0 +1,10 @@
+[
+  "employment_screening",
+  "biometric_id",
+  "critical_infrastructure",
+  "education_scoring",
+  "justice_decision",
+  "migration_control",
+  "essential_services",
+  "law_enforcement"
+]

--- a/annex4ac/tags.py
+++ b/annex4ac/tags.py
@@ -6,7 +6,6 @@ import requests
 from bs4 import BeautifulSoup
 from importlib.resources import files
 from platformdirs import user_cache_dir
-import typer
 
 
 def slugify(text: str) -> str:
@@ -31,8 +30,7 @@ def slugify(text: str) -> str:
 def _fetch_html(url: str) -> str:
     r = requests.get(url, timeout=20)
     if r.status_code != 200:
-        typer.secho(f"ERROR: {url} returned {r.status_code}", fg=typer.colors.RED, err=True)
-        raise typer.Exit(1)
+        raise requests.HTTPError(f"{url} -> HTTP {r.status_code}")
     return r.text
 
 

--- a/annex4ac/tags.py
+++ b/annex4ac/tags.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+import os
+import json
+from datetime import datetime, timedelta
+import requests
+from bs4 import BeautifulSoup
+from importlib.resources import files
+from platformdirs import user_cache_dir
+import typer
+
+
+def slugify(text: str) -> str:
+    """Normalize Annex III tag strings."""
+    return (
+        text.lower()
+        .replace(" ", "_")
+        .replace("-", "_")
+        .replace("–", "_")
+        .replace("—", "_")
+        .replace("/", "_")
+        .replace(".", "")
+        .replace(",", "")
+        .replace(":", "")
+        .replace(";", "")
+        .replace("'", "")
+        .replace('"', "")
+        .strip()
+    )
+
+
+def _fetch_html(url: str) -> str:
+    r = requests.get(url, timeout=20)
+    if r.status_code != 200:
+        typer.secho(f"ERROR: {url} returned {r.status_code}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(1)
+    return r.text
+
+
+def fetch_annex3_tags(cache_path: str | None = None, cache_days: int = 14) -> set[str]:
+    """Return a set of Annex III high-risk tags with caching and packaged fallback."""
+    cache_dir = os.path.dirname(cache_path) if cache_path else user_cache_dir("annex4ac")
+    os.makedirs(cache_dir, exist_ok=True)
+    cache_file = cache_path or os.path.join(cache_dir, "high_risk_tags.json")
+
+    if os.path.exists(cache_file):
+        mtime = datetime.fromtimestamp(os.path.getmtime(cache_file))
+        if datetime.now() - mtime < timedelta(days=cache_days):
+            with open(cache_file, "r", encoding="utf-8") as f:
+                return set(json.load(f))
+
+    try:
+        html = _fetch_html("https://artificialintelligenceact.eu/annex/3/")
+        soup = BeautifulSoup(html, "html.parser")
+        tags = sorted({slugify(li.text) for li in soup.select("ol > li")})
+        if tags:
+            with open(cache_file, "w", encoding="utf-8") as f:
+                json.dump(tags, f, ensure_ascii=False, indent=2)
+            return set(tags)
+        raise RuntimeError("empty tag list")
+    except Exception:
+        data = (
+            files("annex4ac")
+            .joinpath("resources/high_risk_tags.default.json")
+            .read_text(encoding="utf-8")
+        )
+        return set(json.loads(data))

--- a/annex4ac/tags.py
+++ b/annex4ac/tags.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import os
 import json
-import os
 from datetime import datetime, timedelta
 import requests
 from bs4 import BeautifulSoup

--- a/annex4ac/tags.py
+++ b/annex4ac/tags.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 import os
 import json
+import os
 from datetime import datetime, timedelta
 import requests
 from bs4 import BeautifulSoup
 from importlib.resources import files
 from platformdirs import user_cache_dir
+from typing import Optional, Set
 
 
 def slugify(text: str) -> str:
@@ -34,7 +36,7 @@ def _fetch_html(url: str) -> str:
     return r.text
 
 
-def fetch_annex3_tags(cache_path: str | None = None, cache_days: int = 14) -> set[str]:
+def fetch_annex3_tags(cache_path: Optional[str] = None, cache_days: int = 14) -> Set[str]:
     """Return a set of Annex III high-risk tags with caching and packaged fallback."""
     cache_dir = os.path.dirname(cache_path) if cache_path else user_cache_dir("annex4ac")
     os.makedirs(cache_dir, exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "annex4ac"
-version = "1.3.2"
+version = "1.4.0"
 description = "Annex IV-as-Code CLI: generate & validate EU AI Act Annex IV with legal compliance"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -40,7 +40,7 @@ build-backend = "setuptools.build_meta"
 addopts = "-q"
 
 [tool.setuptools.packages.find]
-include = ["annex4ac", "annex4ac.policy"]
+include = ["annex4ac*"]
 
 [tool.setuptools.package-data]
-annex4ac = ["resources/*.icc", "resources/*.json", "fonts/*.ttf", "templates/*.html"]
+annex4ac = ["lic_pub.pem", "resources/*.icc", "resources/*.json", "fonts/*.ttf", "templates/*.html"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
   "python-docx>=1.1",
   "ftfy>=6.0",
   "pikepdf>=8.0",
+  "SQLAlchemy>=2.0",
+  "psycopg[binary]>=3.1",
+  "pydantic-settings>=2",
+  "python-dateutil>=2.9",
+  "platformdirs>=4.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,4 @@ addopts = "-q"
 include = ["annex4ac", "annex4ac.policy"]
 
 [tool.setuptools.package-data]
-annex4ac = ["resources/*.icc", "fonts/*.ttf", "templates/*.html"]
+annex4ac = ["resources/*.icc", "resources/*.json", "fonts/*.ttf", "templates/*.html"]

--- a/tests/test_annex3_cache.py
+++ b/tests/test_annex3_cache.py
@@ -1,0 +1,13 @@
+from annex4ac.annex4ac import fetch_annex3_tags
+
+
+def test_annex3_offline_fallback(monkeypatch, tmp_path):
+    # Simulate network failure
+    def boom(*a, **k):
+        raise RuntimeError("offline")
+    monkeypatch.setattr("annex4ac.annex4ac._fetch_html", boom)
+
+    cache = tmp_path / "tags.json"
+    tags = fetch_annex3_tags(cache_path=str(cache), cache_days=14)
+    assert "biometric_id" in tags and len(tags) >= 8
+    assert cache.exists() is False

--- a/tests/test_annex3_cache.py
+++ b/tests/test_annex3_cache.py
@@ -1,11 +1,11 @@
-from annex4ac.annex4ac import fetch_annex3_tags
+from annex4ac.tags import fetch_annex3_tags
 
 
 def test_annex3_offline_fallback(monkeypatch, tmp_path):
     # Simulate network failure
     def boom(*a, **k):
         raise RuntimeError("offline")
-    monkeypatch.setattr("annex4ac.annex4ac._fetch_html", boom)
+    monkeypatch.setattr("annex4ac.tags._fetch_html", boom)
 
     cache = tmp_path / "tags.json"
     tags = fetch_annex3_tags(cache_path=str(cache), cache_days=14)

--- a/tests/test_fetch_schema_db.py
+++ b/tests/test_fetch_schema_db.py
@@ -1,0 +1,37 @@
+import os
+from typer.testing import CliRunner
+from annex4ac.annex4ac import app
+
+
+def test_fetch_schema_db(monkeypatch, tmp_path):
+    runner = CliRunner()
+
+    class DummySession:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_get_session(url):
+        return DummySession()
+
+    def fake_load_annex_iv_from_db(ses, celex_id):
+        return {"system_overview": "stub"}
+
+    def fake_get_schema_version_from_db(ses, celex_id):
+        return "20240101"
+
+    monkeypatch.setattr("annex4ac.annex4ac.get_session", fake_get_session)
+    monkeypatch.setattr("annex4ac.annex4ac.load_annex_iv_from_db", fake_load_annex_iv_from_db)
+    monkeypatch.setattr("annex4ac.annex4ac.get_schema_version_from_db", fake_get_schema_version_from_db)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / ".cache"))
+
+    out_file = tmp_path / "out.yaml"
+    result = runner.invoke(
+        app,
+        ["fetch-schema", "--db-url", "postgresql+psycopg://u:p@h/db", str(out_file)],
+    )
+    assert result.exit_code == 0
+    assert out_file.exists()
+    assert "system_overview" in out_file.read_text()

--- a/tests/test_fetch_schema_db.py
+++ b/tests/test_fetch_schema_db.py
@@ -15,10 +15,10 @@ def test_fetch_schema_db(monkeypatch, tmp_path):
     def fake_get_session(url):
         return DummySession()
 
-    def fake_load_annex_iv_from_db(ses, celex_id):
+    def fake_load_annex_iv_from_db(ses, regulation_id=None, celex_id=None):
         return {"system_overview": "stub"}
 
-    def fake_get_schema_version_from_db(ses, celex_id):
+    def fake_get_schema_version_from_db(ses, regulation_id=None, celex_id=None):
         return "20240101"
 
     monkeypatch.setattr("annex4ac.annex4ac.get_session", fake_get_session)

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -7,6 +7,7 @@ import os
 import time
 import tempfile
 import pytest
+import click
 from pathlib import Path
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -16,7 +17,7 @@ import jwt
 # Import the function to test
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from annex4ac import _check_license
+from annex4ac.annex4ac import _check_license
 
 def generate_test_keys():
     """Generate test RSA key pair."""
@@ -144,9 +145,9 @@ def test_expired_license():
             os.environ["ANNEX4AC_LICENSE"] = token
             
             # Should raise typer.Exit(1) for expired license
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(click.exceptions.Exit) as exc_info:
                 _check_license()
-            assert exc_info.value.code == 1
+            assert exc_info.value.exit_code == 1
             
         finally:
             importlib.resources.files = original_files
@@ -180,9 +181,9 @@ def test_invalid_plan():
             os.environ["ANNEX4AC_LICENSE"] = token
             
             # Should raise typer.Exit(1) for invalid plan
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(click.exceptions.Exit) as exc_info:
                 _check_license()
-            assert exc_info.value.code == 1
+            assert exc_info.value.exit_code == 1
             
         finally:
             importlib.resources.files = original_files

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -78,17 +78,17 @@ def test_license_validation():
         # Write public key
         (annex4ac_dir / "lic_pub.pem").write_text(public_key)
         
-        # Mock importlib.resources.files
-        import importlib.resources
-        original_files = importlib.resources.files
-        
+        # Mock resource loader
+        import annex4ac.annex4ac as cli_mod
+        original_files = cli_mod.files
+
         def mock_files(package_name):
             class MockFiles:
                 def joinpath(self, path):
                     return Path(annex4ac_dir) / path
             return MockFiles()
-        
-        importlib.resources.files = mock_files
+
+        cli_mod.files = mock_files
         
         try:
             # Set environment variable
@@ -99,7 +99,7 @@ def test_license_validation():
             
         finally:
             # Restore original function
-            importlib.resources.files = original_files
+            cli_mod.files = original_files
             if "ANNEX4AC_LICENSE" in os.environ:
                 del os.environ["ANNEX4AC_LICENSE"]
 
@@ -130,16 +130,16 @@ def test_expired_license():
         annex4ac_dir.mkdir()
         (annex4ac_dir / "lic_pub.pem").write_text(public_key)
         
-        import importlib.resources
-        original_files = importlib.resources.files
-        
+        import annex4ac.annex4ac as cli_mod
+        original_files = cli_mod.files
+
         def mock_files(package_name):
             class MockFiles:
                 def joinpath(self, path):
                     return Path(annex4ac_dir) / path
             return MockFiles()
-        
-        importlib.resources.files = mock_files
+
+        cli_mod.files = mock_files
         
         try:
             os.environ["ANNEX4AC_LICENSE"] = token
@@ -150,7 +150,7 @@ def test_expired_license():
             assert exc_info.value.exit_code == 1
             
         finally:
-            importlib.resources.files = original_files
+            cli_mod.files = original_files
             if "ANNEX4AC_LICENSE" in os.environ:
                 del os.environ["ANNEX4AC_LICENSE"]
 
@@ -166,16 +166,16 @@ def test_invalid_plan():
         annex4ac_dir.mkdir()
         (annex4ac_dir / "lic_pub.pem").write_text(public_key)
         
-        import importlib.resources
-        original_files = importlib.resources.files
-        
+        import annex4ac.annex4ac as cli_mod
+        original_files = cli_mod.files
+
         def mock_files(package_name):
             class MockFiles:
                 def joinpath(self, path):
                     return Path(annex4ac_dir) / path
             return MockFiles()
-        
-        importlib.resources.files = mock_files
+
+        cli_mod.files = mock_files
         
         try:
             os.environ["ANNEX4AC_LICENSE"] = token
@@ -186,7 +186,7 @@ def test_invalid_plan():
             assert exc_info.value.exit_code == 1
             
         finally:
-            importlib.resources.files = original_files
+            cli_mod.files = original_files
             if "ANNEX4AC_LICENSE" in os.environ:
                 del os.environ["ANNEX4AC_LICENSE"]
 

--- a/tests/test_pdfa_resource.py
+++ b/tests/test_pdfa_resource.py
@@ -1,0 +1,7 @@
+from importlib.resources import files
+
+
+def test_srgb_icc_present():
+    icc = files("annex4ac").joinpath("resources/sRGB.icc")
+    assert icc.is_file()
+    assert len(icc.read_bytes()) > 0

--- a/tests/test_validate_db.py
+++ b/tests/test_validate_db.py
@@ -15,13 +15,16 @@ def test_validate_db_sarif(monkeypatch, tmp_path):
     def fake_get_session(url):
         return DummySession()
 
-    def fake_load_annex_iv_from_db(ses, celex_id):
+    def fake_load_annex_iv_from_db(ses, regulation_id=None, celex_id=None):
         return {"system_overview": "stub"}
 
     monkeypatch.setattr("annex4ac.annex4ac.get_session", fake_get_session)
     monkeypatch.setattr("annex4ac.annex4ac.load_annex_iv_from_db", fake_load_annex_iv_from_db)
     monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda payload: ([], []))
-    monkeypatch.setattr("annex4ac.annex4ac.get_expected_top_counts", lambda s, celex_id: {})
+    monkeypatch.setattr(
+        "annex4ac.annex4ac.get_expected_top_counts",
+        lambda s, regulation_id=None, celex_id=None: {},
+    )
 
     yml = tmp_path / "in.yaml"
     yml.write_text("system_overview: ''\n")
@@ -58,7 +61,7 @@ def test_validate_db_subpoints(monkeypatch, tmp_path):
     def fake_get_session(url):
         return DummySession()
 
-    def fake_load_annex_iv_from_db(ses, celex_id):
+    def fake_load_annex_iv_from_db(ses, regulation_id=None, celex_id=None):
         # DB expects two top-level subpoints and three nested items in first
         return {"system_overview": "(a) foo\n  - x\n  - y\n  - z\n(b) bar"}
 
@@ -67,7 +70,7 @@ def test_validate_db_subpoints(monkeypatch, tmp_path):
     monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda payload: ([], []))
     monkeypatch.setattr(
         "annex4ac.annex4ac.get_expected_top_counts",
-        lambda s, celex_id: {"system_overview": 2},
+        lambda s, regulation_id=None, celex_id=None: {"system_overview": 2},
     )
 
     yml = tmp_path / "in.yaml"
@@ -102,12 +105,12 @@ def test_validate_db_counts_ok(monkeypatch, tmp_path):
     monkeypatch.setattr("annex4ac.annex4ac.get_session", lambda url: DummySession())
     monkeypatch.setattr(
         "annex4ac.annex4ac.load_annex_iv_from_db",
-        lambda s, celex_id: {"system_overview": "(a) foo\n  - x\n  - y\n(b) bar"},
+        lambda s, regulation_id=None, celex_id=None: {"system_overview": "(a) foo\n  - x\n  - y\n(b) bar"},
     )
     monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda p: ([], []))
     monkeypatch.setattr(
         "annex4ac.annex4ac.get_expected_top_counts",
-        lambda s, celex_id: {"system_overview": 2},
+        lambda s, regulation_id=None, celex_id=None: {"system_overview": 2},
     )
     class DummyModel:
         last_updated = "2024-01-01"
@@ -144,12 +147,12 @@ def test_validate_db_numbered_ok(monkeypatch, tmp_path):
     # DB expects two subpoints with letters
     monkeypatch.setattr(
         "annex4ac.annex4ac.load_annex_iv_from_db",
-        lambda s, celex_id: {"system_overview": "(a) foo\n(b) bar"},
+        lambda s, regulation_id=None, celex_id=None: {"system_overview": "(a) foo\n(b) bar"},
     )
     monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda p: ([], []))
     monkeypatch.setattr(
         "annex4ac.annex4ac.get_expected_top_counts",
-        lambda s, celex_id: {"system_overview": 2},
+        lambda s, regulation_id=None, celex_id=None: {"system_overview": 2},
     )
     class DummyModel:
         last_updated = "2024-01-01"
@@ -187,12 +190,12 @@ def test_validate_db_roman_subsub(monkeypatch, tmp_path):
     # DB: two subpoints, first has two roman nested items
     monkeypatch.setattr(
         "annex4ac.annex4ac.load_annex_iv_from_db",
-        lambda s, celex_id: {"system_overview": "(a) foo\n  (i) x\n  (ii) y\n(b) bar"},
+        lambda s, regulation_id=None, celex_id=None: {"system_overview": "(a) foo\n  (i) x\n  (ii) y\n(b) bar"},
     )
     monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda p: ([], []))
     monkeypatch.setattr(
         "annex4ac.annex4ac.get_expected_top_counts",
-        lambda s, celex_id: {"system_overview": 2},
+        lambda s, regulation_id=None, celex_id=None: {"system_overview": 2},
     )
 
     yml = tmp_path / "in.yaml"
@@ -227,12 +230,12 @@ def test_validate_db_explain_missing_letters(monkeypatch, tmp_path):
     monkeypatch.setattr("annex4ac.annex4ac.get_session", lambda url: DummySession())
     monkeypatch.setattr(
         "annex4ac.annex4ac.load_annex_iv_from_db",
-        lambda s, celex_id: {"system_overview": "(a) foo\n(b) bar"},
+        lambda s, regulation_id=None, celex_id=None: {"system_overview": "(a) foo\n(b) bar"},
     )
     monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda p: ([], []))
     monkeypatch.setattr(
         "annex4ac.annex4ac.get_expected_top_counts",
-        lambda s, celex_id: {"system_overview": 2},
+        lambda s, regulation_id=None, celex_id=None: {"system_overview": 2},
     )
 
     yml = tmp_path / "in.yaml"

--- a/tests/test_validate_db.py
+++ b/tests/test_validate_db.py
@@ -21,6 +21,7 @@ def test_validate_db_sarif(monkeypatch, tmp_path):
     monkeypatch.setattr("annex4ac.annex4ac.get_session", fake_get_session)
     monkeypatch.setattr("annex4ac.annex4ac.load_annex_iv_from_db", fake_load_annex_iv_from_db)
     monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda payload: ([], []))
+    monkeypatch.setattr("annex4ac.annex4ac.get_expected_top_counts", lambda s, celex_id: {})
 
     yml = tmp_path / "in.yaml"
     yml.write_text("system_overview: ''\n")
@@ -64,6 +65,10 @@ def test_validate_db_subpoints(monkeypatch, tmp_path):
     monkeypatch.setattr("annex4ac.annex4ac.get_session", fake_get_session)
     monkeypatch.setattr("annex4ac.annex4ac.load_annex_iv_from_db", fake_load_annex_iv_from_db)
     monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda payload: ([], []))
+    monkeypatch.setattr(
+        "annex4ac.annex4ac.get_expected_top_counts",
+        lambda s, celex_id: {"system_overview": 2},
+    )
 
     yml = tmp_path / "in.yaml"
     # User supplies only one bullet -> insufficient
@@ -100,6 +105,10 @@ def test_validate_db_counts_ok(monkeypatch, tmp_path):
         lambda s, celex_id: {"system_overview": "(a) foo\n  - x\n  - y\n(b) bar"},
     )
     monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda p: ([], []))
+    monkeypatch.setattr(
+        "annex4ac.annex4ac.get_expected_top_counts",
+        lambda s, celex_id: {"system_overview": 2},
+    )
     class DummyModel:
         last_updated = "2024-01-01"
     monkeypatch.setattr("annex4ac.annex4ac.AnnexIVSchema", lambda **p: DummyModel())
@@ -138,6 +147,10 @@ def test_validate_db_numbered_ok(monkeypatch, tmp_path):
         lambda s, celex_id: {"system_overview": "(a) foo\n(b) bar"},
     )
     monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda p: ([], []))
+    monkeypatch.setattr(
+        "annex4ac.annex4ac.get_expected_top_counts",
+        lambda s, celex_id: {"system_overview": 2},
+    )
     class DummyModel:
         last_updated = "2024-01-01"
 
@@ -177,6 +190,10 @@ def test_validate_db_roman_subsub(monkeypatch, tmp_path):
         lambda s, celex_id: {"system_overview": "(a) foo\n  (i) x\n  (ii) y\n(b) bar"},
     )
     monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda p: ([], []))
+    monkeypatch.setattr(
+        "annex4ac.annex4ac.get_expected_top_counts",
+        lambda s, celex_id: {"system_overview": 2},
+    )
 
     yml = tmp_path / "in.yaml"
     # User provides only one roman nested item

--- a/tests/test_validate_db.py
+++ b/tests/test_validate_db.py
@@ -20,7 +20,7 @@ def test_validate_db_sarif(monkeypatch, tmp_path):
 
     monkeypatch.setattr("annex4ac.annex4ac.get_session", fake_get_session)
     monkeypatch.setattr("annex4ac.annex4ac.load_annex_iv_from_db", fake_load_annex_iv_from_db)
-    monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda payload, sarif_path=None, yaml_path=None: [])
+    monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda payload: [])
 
     yml = tmp_path / "in.yaml"
     yml.write_text("system_overview: ''\n")

--- a/tests/test_validate_db.py
+++ b/tests/test_validate_db.py
@@ -20,7 +20,7 @@ def test_validate_db_sarif(monkeypatch, tmp_path):
 
     monkeypatch.setattr("annex4ac.annex4ac.get_session", fake_get_session)
     monkeypatch.setattr("annex4ac.annex4ac.load_annex_iv_from_db", fake_load_annex_iv_from_db)
-    monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda payload: [])
+    monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda payload: ([], []))
 
     yml = tmp_path / "in.yaml"
     yml.write_text("system_overview: ''\n")

--- a/tests/test_validate_db.py
+++ b/tests/test_validate_db.py
@@ -259,4 +259,4 @@ def test_validate_db_explain_missing_letters(monkeypatch, tmp_path):
     assert result.exit_code == 1
     assert "Missing: (b)" in result.output
     data = json.loads(sarif.read_text())
-    assert data["runs"][0]["results"][0]["help"]["text"] == "Missing subpoints: (b)"
+    assert data["runs"][0]["results"][0]["properties"]["help"] == "Missing subpoints: (b)"

--- a/tests/test_validate_db.py
+++ b/tests/test_validate_db.py
@@ -1,0 +1,44 @@
+import json
+from typer.testing import CliRunner
+from annex4ac.annex4ac import app
+
+
+def test_validate_db_sarif(monkeypatch, tmp_path):
+    runner = CliRunner()
+
+    class DummySession:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_get_session(url):
+        return DummySession()
+
+    def fake_load_annex_iv_from_db(ses, celex_id):
+        return {"system_overview": "stub"}
+
+    monkeypatch.setattr("annex4ac.annex4ac.get_session", fake_get_session)
+    monkeypatch.setattr("annex4ac.annex4ac.load_annex_iv_from_db", fake_load_annex_iv_from_db)
+    monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda payload, sarif_path=None, yaml_path=None: [])
+
+    yml = tmp_path / "in.yaml"
+    yml.write_text("system_overview: ''\n")
+    sarif = tmp_path / "out.sarif"
+
+    result = runner.invoke(
+        app,
+        [
+            "validate",
+            str(yml),
+            "--use-db",
+            "--db-url",
+            "postgresql+psycopg://u:p@h/db",
+            "--sarif",
+            str(sarif),
+        ],
+    )
+
+    assert result.exit_code == 1
+    data = json.loads(sarif.read_text())
+    assert data["runs"][0]["results"][0]["ruleId"] == "system_overview_required"

--- a/tests/test_validate_db.py
+++ b/tests/test_validate_db.py
@@ -42,3 +42,41 @@ def test_validate_db_sarif(monkeypatch, tmp_path):
     assert result.exit_code == 1
     data = json.loads(sarif.read_text())
     assert data["runs"][0]["results"][0]["ruleId"] == "system_overview_required"
+
+
+def test_validate_db_subpoints(monkeypatch, tmp_path):
+    runner = CliRunner()
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_get_session(url):
+        return DummySession()
+
+    def fake_load_annex_iv_from_db(ses, celex_id):
+        return {"system_overview": "(a) foo\n(b) bar"}
+
+    monkeypatch.setattr("annex4ac.annex4ac.get_session", fake_get_session)
+    monkeypatch.setattr("annex4ac.annex4ac.load_annex_iv_from_db", fake_load_annex_iv_from_db)
+    monkeypatch.setattr("annex4ac.annex4ac._validate_payload", lambda payload: ([], []))
+
+    yml = tmp_path / "in.yaml"
+    yml.write_text("system_overview: '(a) foo'\n")
+
+    result = runner.invoke(
+        app,
+        [
+            "validate",
+            str(yml),
+            "--use-db",
+            "--db-url",
+            "postgresql+psycopg://u:p@h/db",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "system_overview_b_required" in result.output

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -1,6 +1,6 @@
 import pytest
 import yaml
-from policy.annex4ac_validate import validate_payload
+from annex4ac.policy.annex4ac_validate import validate_payload
 from annex4ac import fetch_annex3_tags
 
 # Check for errors and warnings


### PR DESCRIPTION
## Summary
- expose database/web selection with a `--source-preference` flag, use `platformdirs` for cache storage, and emit friendlier DB-only error messages
- validate payloads by default in `generate` with an opt-out `--skip-validation` flag
- document PostgreSQL-specific database usage, cross-platform cache location, and new CLI flags; add `platformdirs` dependency
- cover database cross-checks with a SARIF test and adjust existing tests for new imports and CLI semantics

## Testing
- `pip install -e .`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f12646810832995f1e76975533a59