### PR TITLE
Fix roman numeral parsing and enable explanations by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ annex4ac validate my_annex.yaml   # "Validation OK!" or exit 1
 annex4ac validate my_annex.yaml --stale-after 30  # Warn if older than 30 days
 annex4ac validate my_annex.yaml --stale-after 180 --strict-age  # Fail CI if older than 180 days
 # Cross-check sections against the database and emit SARIF for GitHub
-annex4ac validate my_annex.yaml --use-db --db-url "$ANNEX4AC_DB_URL" --explain --sarif out.sarif
-# --explain lists missing lettered subpoints like (c) or (d). This checks the minimum required count of
+annex4ac validate my_annex.yaml --use-db --db-url "$ANNEX4AC_DB_URL" --sarif out.sarif
+# --no-explain hides missing lettered subpoints like (c) or (d). This checks the minimum required count of
 # top-level and nested subpoints, not literal (a)/(b)/(c) markers
 
 # 4 Generate output (PDF requires license)

--- a/tests/test_roman_regex.py
+++ b/tests/test_roman_regex.py
@@ -1,0 +1,22 @@
+from annex4ac.annex4ac import _extract_letters, _count_subpoints_db
+
+
+def test_count_subpoints_db_handles_non_roman_letters():
+    text = (
+        "(a) one\n"
+        "(b) two\n"
+        "(c) three\n"
+        "(d) four\n"
+        "(e) five\n"
+        "(f) six\n"
+        "(g) seven\n"
+        "(h) eight"
+    )
+    n_top, _ = _count_subpoints_db(text)
+    assert n_top == 8
+
+
+def test_extract_letters_skips_roman_numerals():
+    text = "(a) foo\n(i) x\n(ii) y\n(b) bar\n(c) baz\n"
+    assert _extract_letters(text) == ["a", "b", "c"]
+


### PR DESCRIPTION
## Summary
- Restrict roman numeral regex to `i`, `v`, `x` so lettered subpoints like `(c)` are preserved
- Treat empty `--celex-id` values as `None` and enable `--explain` output by default
- Document `--no-explain` option and add regression tests for roman numeral filtering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4b6f09c7083299f99e5163b7a7a9c